### PR TITLE
added support for nanos

### DIFF
--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,0 +1,1 @@
+{"buildTargets":["dev-mode-vsc","generate-docs","install-dev","make.exe","test"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/.vscode/dryrun.log
+++ b/.vscode/dryrun.log
@@ -1,0 +1,5 @@
+make.exe --dry-run --always-make --keep-going --print-directory
+make.exe: Entering directory `c:/Users/mjdav/source/repos/Rust/sonotube/duration-string'
+cargo test --features="serde"
+make.exe: Leaving directory `c:/Users/mjdav/source/repos/Rust/sonotube/duration-string'
+ 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/.vscode/targets.log
+++ b/.vscode/targets.log
@@ -1,0 +1,335 @@
+make.exe all --print-data-base --no-builtin-variables --no-builtin-rules --question
+# GNU Make 3.81
+# Copyright (C) 2006  Free Software Foundation, Inc.
+# This is free software; see the source for copying conditions.
+# There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.
+
+# This program built for i386-pc-mingw32
+ 
+
+# Make data base, printed on Tue May 31 08:45:07 2022
+
+# Variables
+
+# environment
+POWERSHELL_DISTRIBUTION_CHANNEL = MSI:Windows 10 Pro
+# automatic
+?F = $(notdir $?)
+# automatic
+<D = $(patsubst %/,%,$(dir $<))
+# makefile
+MAKEFLAGS = Rrqp
+# environment
+VSCODE_LOG_NATIVE = false
+# environment
+CUDA_PATH_V11_5 = C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5
+# automatic
+?D = $(patsubst %/,%,$(dir $?))
+# automatic
+@D = $(patsubst %/,%,$(dir $@))
+# environment
+HOMEDRIVE = C:
+# automatic
+@F = $(notdir $@ 
+)
+# automatic
+^D = $(patsubst %/,%,$(dir $^))
+# makefile
+CURDIR := c:/Users/mjdav/source/repos/Rust/sonotube/duration-string
+# default
+SHELL := C:/Program Files/Git/usr/bin/sh.exe
+# environment
+WINDIR = C:\WINDOWS
+# environment
+VSCODE_NLS_CONFIG = {"locale":"en-us","availableLanguages":{},"_languagePackSupport":true}
+# environment
+ONEDRIVE = C:\Users\mjdav\OneDrive - Publicis Groupe
+# environment
+PATHEXT = .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+# makefile (from `makefile', line 1)
+MAKEFILE_LIST :=  makefile
+# environment
+TMP = C:\Users\mjdav\AppData\Local\Temp
+# environment
+VSCODE_VERBOSE_LOGGING = true
+# environment
+PROGRAMW6432 = C:\Program Files
+# environment
+PROGRAMDATA = C:\ProgramData
+# environment
+VSCODE_IPC_HOOK_EXTHOST = \\.\pipe\vscode-ipc-c45a6c28-d5e5-46e6-a576-4cb8f40bf7c5-sock
+# environment
+VSCODE_CWD = C:\WINDOWS\system32
+# environment
+PATH = C:\Program Files\Microsoft\jdk-11.0.12.7-hotspot\bin;C:\Program Files\Eclipse Foundation\jdk-8.0.302.8-hotspot\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5\libnvvp;C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ProgramData\chocolatey\bin;C:\Program Files\nodejs\;C:\Program Files\Go\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\CMake\bin;C:\Program Files\NVIDIA Corporation\Nsight Compute 2021.3.0\;C:\Program Files\dotnet\;C:\Program Files\Docker\Docker\resources\bin;C:\ProgramData\DockerDesktop\version-bin;C:\Program Files\Microsoft SQL Server\150\Tools\Binn\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\PowerShell\7\;C:\Users\mjdav\.cargo\bin;C:\Users\mjdav\AppData\Local\Programs\Python\Python310\Scripts\;C:\Users\mjdav\AppData\Local\Programs\Python\Python310\;C:\Users\mjdav\AppData\Local\Microsoft\WindowsApps;C:\Users\mjdav\AppData\Local\Programs\Microsoft VS Code\bin;C:\tools\flutter\bin;C:\Users\mjdav\AppData\Roaming\npm;C:\Users\mjdav\go\bin;C:\Users\mjdav\.dotnet\tools;C:\Users\mjdav\AppData\Local\Box\Box Edit\;C:\Program Files (x86)\GnuWin32\bin;
+# environment
+COMMONPROGRAMW6432 = C:\Program Files\Common Files
+# environment
+CHOCOLATEYLASTPATHUPDATE = 132467232365051414
+# environment
+PROCESSOR_ARCHITECTURE = x86
+# environment
+USERPROFILE = C:\Users\mjdav
+# environment
+CHOCOLATEYINSTALL = C:\ProgramData\chocolatey
+# environment
+ALLUSERSPROFILE = C:\ProgramData
+# environment
+GOPATH = C:\Users\mjdav\go
+# environment
+VSCODE_LOG_STACK = false
+# environment
+NUMBER_OF_PROCESSORS = 20
+# environment
+ELECTRON_RUN_AS_NODE = 1
+# default
+.FEATURES := target-specific order-only second-expansion else-if archives
+# environment
+NVTOOLSEXT_PATH = C:\Program Files\NVIDIA Corporation\NvToolsExt\
+# automatic
+%F = $(notdir $%)
+# environment
+CHROME_CRASHPAD_PIPE_NAME = \\.\pipe\crashpad_35436_JFXOXXMDWCZALVQG
+# environment
+VSCODE_PIPE_LOGGING = true
+# environment
+COMPUTERNAME = GTHANG
+# environment
+PROGRAMFILES = C:\Program Files (x86)
+# environment
+DRIVERDATA = C:\Windows\System32\Drivers\DriverData
+# environment
+NVCUDASAMPLES_ROOT = C:\ProgramData\NVIDIA Corporation\CUDA Samples\v11.5
+# environment
+ORIGINAL_XDG_CURRENT_DESKTOP = undefined
+# environment
+USERNAME = mjdav
+# environment
+PUBLIC = C:\Users\Public
+# environment
+VSCODE_AMD_ENTRYPOINT = vs/workbench/api/node/extensionHostProcess
+# environment
+VSCODE_CODE_CACHE_PATH = C:\Users\mjdav\AppData\Roaming\Code\CachedData\c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
+# environment
+APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL = 1
+# environment
+COMMONPROGRAMFILES = C:\Program Files (x86)\Common Files
+# environment
+LOGONSERVER = \\GTHANG
+# environment
+ONEDRIVECONSUMER = C:\Users\mjdav\OneDrive
+# environment
+VSCODE_HANDLES_UNCAUGHT_ERRORS = true
+# environment
+USERDOMAIN = GTHANG
+# default
+MAKE = $(MAKE_COMMAND)
+# default
+MAKECMDGOALS := all
+# environment
+ONEDRIVECOMMERCIAL = C:\Users\mjdav\OneDrive - Publicis Groupe
+# default
+MAKE_VERSION := 3.81
+# makefile
+.DEFAULT_GOAL := test
+# environment
+PROGRAMFILES(X86) = C:\Program Files (x86)
+# automatic
+%D = $(patsubst %/,%,$(dir $%))
+# environment
+LOCALAPPDATA = C:\Users\mjdav\AppData\Local
+# environment
+PSMODULEPATH = C:\Program Files\WindowsPowerShell\Modules;C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+# default
+MAKE_COMMAND := make.exe
+# environment
+NVCUDASAMPLES11_5_ROOT = C:\ProgramData\NVIDIA Corporation\CUDA Samples\v11.5
+# environment
+PROCESSOR_ARCHITEW6432 = AMD64
+# default
+.VARIABLES := 
+# automatic
+*F = $(notdir $*)
+# environment
+PROCESSOR_IDENTIFIER 
+ = Intel64 Family 6 Model 165 Stepping 5, GenuineIntel
+# environment
+OS = Windows_NT
+# environment
+VSCODE_IPC_HOOK = \\.\pipe\111c8faef46d1e239eb60676b5ca08cd-1.67.2-main-sock
+# environment
+HOMEPATH = \Users\mjdav
+# environment
+COMMONPROGRAMFILES(X86) = C:\Program Files (x86)\Common Files
+# environment
+PROMPT = $P$G
+# environment
+MFLAGS = -Rrqp
+# automatic
+*D = $(patsubst %/,%,$(dir $*))
+# environment
+SYSTEMROOT = C:\WINDOWS
+# automatic
++D = $(patsubst %/,%,$(dir $+))
+# automatic
++F = $(notdir $+)
+# environment
+APPDATA = C:\Users\mjdav\AppData\Roaming
+# environment
+TEMP = C:\Users\mjdav\AppData\Local\Temp
+# environment
+COMSPEC = C:\WINDOWS\system32\cmd.exe
+# default
+MAKEFILES := 
+# automatic
+<F = $(notdir $<)
+# environment
+LC_ALL = C
+# automatic
+^F = $(notdir $^)
+# environment
+CUDA_PATH = C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5
+# default
+SUFFIXES := 
+# environment
+SYSTEMDRIVE = C:
+# environment
+SESSIONNAME = Console
+# environment
+PROCESSOR_REVISION = a505
+# environment
+MAKELEVEL := 0
+# enviro 
+nment
+LANG = C
+# environment
+PROCESSOR_LEVEL = 6
+# environment
+VSCODE_PID = 35436
+# environment
+USERDOMAIN_ROAMINGPROFILE = GTHANG
+# variable set hash-table stats:
+# Load=97/1024=9%, Rehash=0, Collisions=10/116=9%
+
+# Pattern-specific Variable Values
+
+# No pattern-specific variable values.
+
+# Directories
+
+# C:\Program Files\Microsoft\jdk-11.0.12.7-hotspot\bin (key C:/Program Files/Microsoft/jdk-11.0.12.7-hotspot/bin, mtime 1649773904): 127 files, no impossibilities.
+# C:\Program Files\Eclipse Foundation\jdk- 
+8.0.302.8-hotspot\bin (key C:/Program Files/Eclipse Foundation/jdk-8.0.302.8-hotspot/bin, mtime 1638209137): 53 files, no impossibilities.
+# C:\Windows\System32\WindowsPowerShell\v1.0\ (key C:/Windows/System32/WindowsPowerShell/v1.0/, mtime 1653279693): 29 files, no impossibilities.
+# C:\Windows\System32\Wbem (key C:/Windows/System32/Wbem, mtime 1653593704): 299 files, no impossibilities.
+# . (key c:/Users/mjdav/source/repos/Rust/sonotube/duration-string, mtime 1653999279): 12 files, no impossibilities.
+# C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common (key C:/Program Files (x86)/NVIDIA Corporation/PhysX/Common, mtime 1600412818): 10 files, no impossibilities.
+# C:\Program Files\Git\mingw64\bin (key C:/Program Files/Git/mingw64/bin, mtime 1601416690): 124 files, no impossibilities.
+# C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5\bin (key C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.5/bin, mtime 1637094690): 44 files, no impossibilities.
+# C:\Windows\System32\OpenSSH\: could not be  
+stat'd.
+# C:\Program Files\Microsoft SQL Server\130\Tools\Binn\ (key C:/Program Files/Microsoft SQL Server/130/Tools/Binn/, mtime 1601301030): 4 files, no impossibilities.
+# C:\Windows (key C:/Windows, mtime 1653593802): 127 files, no impossibilities.
+# C:\Program Files\Git\usr\bin (key C:/Program Files/Git/usr/bin, mtime 1601416690): 346 files, no impossibilities so far.
+# C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\ (key C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/170/Tools/Binn/, mtime 1601301034): 7 files, no impossibilities.
+# C:\Program Files\Git\cmd (key C:/Program Files/Git/cmd, mtime 1601416690): 8 files, no impossibilities.
+# C:\Windows\system32 (key C:/Windows/system32, mtime 1653998754): 3024 files, no impossibilities.
+# C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin (key C:/Program Files (x86)/Microsoft SDKs/Azure/CLI2/wbin, mtime 1619527711): 4 files, no impossibilities.
+# C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.5\libnvvp (key C:/Program F 
+iles/NVIDIA GPU Computing Toolkit/CUDA/v11.5/libnvvp, mtime 1637094687): 14 files, no impossibilities.
+# C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR (key C:/Program Files/NVIDIA Corporation/NVIDIA NvDLISR, mtime 1600412829): 5 files, no impossibilities.
+
+# 4237 files, no impossibilities in 18 directories.
+
+# Implicit Rules
+
+# No implicit rules.
+
+# Files
+
+dev-mode-vsc:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (f 
+rom `makefile', line 10):
+	cargo watch -x "tarpaulin --run-types Tests --out Lcov --output-dir coverage; cargo test --doc; cargo doc" # VSCODE - Coverage Gutters
+	
+
+# Not a target:
+all:
+#  Command-line target.
+#  Implicit rule search has been done.
+#  File does not exist.
+#  File has not been updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+install-dev:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `makefile', line 4):
+	cargo install cargo-tarpaulin
+	cargo install cargo-watch
+	cargo install cargo-readme
+	
+
+# Not a target:
+.DEFAULT:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+test:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `makefile', line 2):
+	cargo test --features="serde"
+	
+
+# Not a target:
+makefile:
+#  Implicit rule sear 
+ch has been done.
+#  Last modified 2022-05-31 08:10:34
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+.SUFFIXES:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+generate-docs:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `makefile', line 8):
+	cargo readme > r 
+make.exe: *** No rule to make target `all'.  Stop.
+
+eadme.md
+	
+
+# files hash-table stats:
+# Load=8/1024=1%, Rehash=0, Collisions=0/19=0%
+# VPATH Search Paths
+
+# No `vpath' search paths.
+
+# No general (`VPATH' variable) search path.
+
+# # of strings in strcache: 1
+# # of strcache buffers: 1
+# strcache size: total = 4096 / max = 4096 / min = 4096 / avg = 4096
+# strcache free: total = 4087 / max = 4087 / min = 4087 / avg = 4087
+
+# Finished Make data base on Tue May 31 08:45:07 2022
+
+ 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ impl TryFrom<String> for DurationString {
 
         match period.parse::<u64>() {
             Ok(period) => match format.as_str() {
+                "ns" => Ok(DurationString {
+                    inner: Duration::from_nanos(period),
+                }),
                 "ms" => Ok(DurationString {
                     inner: Duration::from_millis(period),
                 }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,12 +56,15 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-const YEAR_IN_MILLI: u128 = 31_556_926_000;
-const WEEK_IN_MILLI: u128 = 604_800_000;
-const DAY_IN_MILLI: u128 = 86_400_000;
-const HOUR_IN_MILLI: u128 = 3_600_000;
-const MINUTE_IN_MILLI: u128 = 60_000;
-const SECOND_IN_MILLI: u128 = 1000;
+
+const YEAR_IN_NANO: u128 = 31_556_926_000_000_000;
+const WEEK_IN_NANO: u128 = 604_800_000_000_000;
+const DAY_IN_NANO: u128 = 86_400_000_000_000;
+const HOUR_IN_NANO: u128 = 3_600_000_000_000;
+const MINUTE_IN_NANO: u128 = 60_000_000_000;
+const SECOND_IN_NANO: u128 = 1000_000_000;
+const MILLISECOND_IN_NANO: u128 = 1000_000;
+const MICROSECOND_IN_NANO: u128 = 1000;
 
 const HOUR_IN_SECONDS: u32 = 3600;
 const MINUTE_IN_SECONDS: u32 = 60;
@@ -99,26 +102,32 @@ impl Into<Duration> for DurationString {
 
 impl Into<String> for DurationString {
     fn into(self) -> String {
-        let ms = self.inner.as_millis();
-        if ms % YEAR_IN_MILLI == 0 {
-            return (ms / YEAR_IN_MILLI).to_string() + "y";
+        let ns = self.inner.as_nanos();
+        if ns % YEAR_IN_NANO == 0 {
+            return (ns / YEAR_IN_NANO).to_string() + "y";
         }
-        if ms % WEEK_IN_MILLI == 0 {
-            return (ms / WEEK_IN_MILLI).to_string() + "w";
+        if ns % WEEK_IN_NANO == 0 {
+            return (ns / WEEK_IN_NANO).to_string() + "w";
         }
-        if ms % DAY_IN_MILLI == 0 {
-            return (ms / DAY_IN_MILLI).to_string() + "d";
+        if ns % DAY_IN_NANO == 0 {
+            return (ns / DAY_IN_NANO).to_string() + "d";
         }
-        if ms % HOUR_IN_MILLI == 0 {
-            return (ms / HOUR_IN_MILLI).to_string() + "h";
+        if ns % HOUR_IN_NANO == 0 {
+            return (ns / HOUR_IN_NANO).to_string() + "h";
         }
-        if ms % MINUTE_IN_MILLI == 0 {
-            return (ms / MINUTE_IN_MILLI).to_string() + "m";
+        if ns % MINUTE_IN_NANO == 0 {
+            return (ns / MINUTE_IN_NANO).to_string() + "m";
         }
-        if ms % SECOND_IN_MILLI == 0 {
-            return (ms / SECOND_IN_MILLI).to_string() + "s";
+        if ns % SECOND_IN_NANO == 0 {
+            return (ns / SECOND_IN_NANO).to_string() + "s";
         }
-        return ms.to_string() + "ms";
+        if ns % MILLISECOND_IN_NANO == 0 {
+            return (ns / MILLISECOND_IN_NANO).to_string() + "ms";
+        }
+        if ns % MICROSECOND_IN_NANO == 0 {
+            return (ns / MICROSECOND_IN_NANO).to_string() + "us";
+        }
+        return ns.to_string() + "ns";
     }
 }
 
@@ -148,6 +157,9 @@ impl TryFrom<String> for DurationString {
                 "ns" => Ok(DurationString {
                     inner: Duration::from_nanos(period),
                 }),
+                "us" => Ok(DurationString {
+                    inner: Duration::from_micros(period),
+                }),
                 "ms" => Ok(DurationString {
                     inner: Duration::from_millis(period),
                 }),
@@ -170,7 +182,7 @@ impl TryFrom<String> for DurationString {
                     inner: Duration::from_secs(period) * YEAR_IN_SECONDS,
                 }),
                 _ => Err(String::from(
-                    "missing TimeDuration format - must be [0-9]+(ms|[smhdwy]",
+                    "missing TimeDuration format - must be [0-9]+(ns|us|ms|[smhdwy]",
                 )),
             },
             Err(err) => Err(err.to_string()),
@@ -296,12 +308,29 @@ mod tests {
             .into();
         assert_eq!(d, String::from("100ms"));
     }
+
     #[test]
     fn test_from_string_ms() {
         let d: Duration = DurationString::try_from(String::from("100ms"))
             .unwrap()
             .into();
         assert_eq!(d, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_from_string_us() {
+        let d: Duration = DurationString::try_from(String::from("100us"))
+            .unwrap()
+            .into();
+        assert_eq!(d, Duration::from_micros(100));
+    }
+
+    #[test]
+    fn test_from_string_ns() {
+        let d: Duration = DurationString::try_from(String::from("100ns"))
+            .unwrap()
+            .into();
+        assert_eq!(d, Duration::from_nanos(100));
     }
 
     #[test]


### PR DESCRIPTION
This test was failing in my code with a panic. Then I read the doc and saw nanoseconds was not supported. I made this simple change to account for nanoseconds and this test now passes.

#[test]
fn test_duration_string()
{
    let nanos_20:Duration = DurationString::from_string("20ns".to_string()).unwrap().into();
    assert_eq!(20,nanos_20.subsec_nanos());
}