### PR TITLE
Implement FromStr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ license-file = "LICENSE"
 keywords = ["duration"]
 categories = ["date-and-time"]
 exclude = ["coverage/**/*"]
-version = "0.1.1"
-authors = ["Ronni Skansing <rskansing@gmail.com>", "Martin Davy <mjdavy@hotmail.com>"]
+version = "0.2.0"
+authors = [
+    "Ronni Skansing <rskansing@gmail.com>",
+    "Martin Davy <mjdavy@hotmail.com>",
+    "Philip Sequeira <qmega@sksm.net>",
+]
 edition = "2018"
 
 [features]

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ use duration_string::DurationString;
 use std::time::Duration;
 let d: Duration = DurationString::try_from(String::from("100ms")).unwrap().into();
 assert_eq!(d, Duration::from_millis(100));
+// Alternatively:
+let d: Duration = "100ms".parse::<DurationString>().unwrap().into();
+assert_eq!(d, Duration::from_millis(100));
 ```
 duration to string
 ```rust

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 Takes a string such as `100ms`, `2s`, `5m` and converts it into a `Duration`
 Takes a duration and makes it into string.
 
-The string format is [0-9]+(ns|us|ms|[smhdwy])
+The string format is `[0-9]+(ns|us|ms|[smhdwy])`
 
 ### Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,63 +316,62 @@ mod tests {
             .into();
         assert_eq!(d, String::from("100ms"));
     }
+
+    fn test_parse_string(input_str: &str, expected_duration: Duration) {
+        let d_fromstr: Duration = input_str
+            .parse::<DurationString>()
+            .expect("Parse with FromStr failed")
+            .into();
+        assert_eq!(d_fromstr, expected_duration, "FromStr");
+        let d_using_tryfrom: Duration = DurationString::try_from(input_str.to_owned())
+            .expect("Parse with TryFrom failed")
+            .into();
+        assert_eq!(d_using_tryfrom, expected_duration, "TryFrom");
+    }
+
     #[test]
     fn test_from_string_ms() {
-        let d: Duration = DurationString::try_from(String::from("100ms"))
-            .unwrap()
-            .into();
-        assert_eq!(d, Duration::from_millis(100));
+        test_parse_string("100ms", Duration::from_millis(100));
     }
+
     #[test]
     fn test_from_string_us() {
-        let d: Duration = DurationString::try_from(String::from("100us"))
-            .unwrap()
-            .into();
-        assert_eq!(d, Duration::from_micros(100));
+        test_parse_string("100us", Duration::from_micros(100));
     }
 
     #[test]
     fn test_from_string_ns() {
-        let d: Duration = DurationString::try_from(String::from("100ns"))
-            .unwrap()
-            .into();
-        assert_eq!(d, Duration::from_nanos(100));
+        test_parse_string("100ns", Duration::from_nanos(100));
     }
 
     #[test]
     fn test_from_string_s() {
-        let d: Duration = DurationString::try_from(String::from("1s")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(1));
+        test_parse_string("1s", Duration::from_secs(1));
     }
 
     #[test]
     fn test_from_string_m() {
-        let d: Duration = DurationString::try_from(String::from("1m")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(60));
+        test_parse_string("1m", Duration::from_secs(60));
     }
 
     #[test]
     fn test_from_string_h() {
-        let d: Duration = DurationString::try_from(String::from("1h")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(3600));
+        test_parse_string("1h", Duration::from_secs(3600));
     }
 
     #[test]
     fn test_from_string_d() {
-        let d: Duration = DurationString::try_from(String::from("1d")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(86_400));
+        test_parse_string("1d", Duration::from_secs(86_400));
     }
 
     #[test]
     fn test_from_string_w() {
-        let d: Duration = DurationString::try_from(String::from("1w")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(604_800));
+        test_parse_string("1w", Duration::from_secs(604_800));
     }
 
     #[test]
     fn test_from_string_y() {
-        let d: Duration = DurationString::try_from(String::from("1y")).unwrap().into();
-        assert_eq!(d, Duration::from_secs(31_556_926));
+        test_parse_string("1y", Duration::from_secs(31_556_926));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use std::fmt;
 use std::fmt::Display;
 #[cfg(feature = "serde")]
 use std::marker::PhantomData;
+use std::str::FromStr;
 use std::time::Duration;
 
 const YEAR_IN_NANO: u128 = 31_556_926_000_000_000;
@@ -140,6 +141,14 @@ impl TryFrom<String> for DurationString {
     type Error = String;
 
     fn try_from(duration: String) -> Result<Self, Self::Error> {
+        duration.parse()
+    }
+}
+
+impl FromStr for DurationString {
+    type Err = String;
+
+    fn from_str(duration: &str) -> Result<Self, Self::Err> {
         let mut format: String = String::from("");
         let mut period: String = String::from("");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@
 //! use std::time::Duration;
 //! let d: String = DurationString::from(Duration::from_millis(100)).into();
 //! assert_eq!(d, String::from("100ms"));
+//! // Alternatively:
+//! let d: Duration = "100ms".parse::<DurationString>().unwrap().into();
+//! assert_eq!(d, Duration::from_millis(100));
 //! ```
 //!
 //! ## Serde support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! Takes a string such as `100ms`, `2s`, `5m` and converts it into a `Duration`
 //! Takes a duration and makes it into string.
 //!
-//! The string format is [0-9]+(ms|us|ns|[smhdwy])
+//! The string format is `[0-9]+(ns|us|ms|[smhdwy])`
 //!
 //! ## Example
 //!
@@ -190,7 +190,7 @@ impl FromStr for DurationString {
                     inner: Duration::from_secs(period) * YEAR_IN_SECONDS,
                 }),
                 _ => Err(String::from(
-                    "missing TimeDuration format - must be [0-9]+(ns|us|ms|[smhdwy]",
+                    "missing TimeDuration format - must be [0-9]+(ns|us|ms|[smhdwy])",
                 )),
             },
             Err(err) => Err(err.to_string()),


### PR DESCRIPTION
My use case was for derive-based parsing with [bpaf](https://docs.rs/bpaf/latest/bpaf/).
Implementing FromStr allows usage like this:
```rs
#[derive(Clone, Bpaf)]
#[bpaf(options)]
struct Arguments {
    /// How long to wait before giving up (if not specified, wait forever)
    timeout: Option<DurationString>,
    ...
}
```
and working arg-parsing code gets generated automatically.

The existing TryFrom implementation had the same semantics so I just used that, but since that took ownership and FromStr only needs a reference (as does the actual conversion code), I made the old function defer to the new one.

Second commit is just fixing a typo (missing ")" in error message), making the 3 instances of the format pattern match (kept the one with all units in increasing length order) and putting it in a code block in the readme. If you don't like the code block, I'm not particularly attached to it.