### PR TITLE
Gate the serde doc test behind feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 //! - Add `serde` to the dependency
 //! `duration-string = { version = "0.0.1", features = ["serde"] }`
 //! - Add derive to struct
+#![cfg_attr(feature = "serde", doc = "```")]
+#![cfg_attr(not(feature = "serde"), doc = "```ignore")]
 //! ```
 //! use serde::{Deserialize, Serialize};
 //! use serde_json;


### PR DESCRIPTION
Under current behaviour `cargo test` fails due to serde doc test. With this commit the test is ignored unless feature flag is passed: `cargo test --features serde`.