### PR TITLE
Add basic GitHub build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Make sure CI fails on all warnings, including Clippy lints
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Lint
+      run: |
+        cargo fmt --all -- --check
+        cargo clippy --all-targets --all-features
+    - name: Build
+      run: cargo build --verbose --all-features
+    - name: Run tests
+      run: cargo test --verbose --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,8 +261,6 @@ mod tests {
     use super::*;
     #[cfg(feature = "serde")]
     use serde::{Deserialize, Serialize};
-    #[cfg(feature = "serde")]
-    use serde_json;
 
     #[cfg(feature = "serde")]
     #[derive(Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ mod tests {
             Ok(v) => {
                 assert_eq!(v.d.to_string(), "2m");
             }
-            Err(err) => assert!(false, "failed to deserialize: {}", err),
+            Err(err) => panic!("failed to deserialize: {}", err),
         }
     }
 


### PR DESCRIPTION
This is based on the default workflow proposed by GitHub + added `rustfmt` and `clippy` checks and added `RUSTFLAGS: "-Dwarnings"` to [make clippy warnings into errors](https://doc.rust-lang.org/nightly/clippy/continuous_integration/github_actions.html).

Also added two small fixes proposed by clippy to make the workflow pass.

Addresses #8